### PR TITLE
Add a note on where to get finished builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This set of scripts supports building GCC Ada, or GNAT, on macOS as a native com
 
 `python3` is required. If not installed, you can download a binary from [python.org](https://www.python.org).
 
+## Ready-built binaries
+If you are simply interested in the resulting builds you can check out the releases of [simonjwright/distributing-gcc](https://github.com/simonjwright/distributing-gcc/releases).
+
 ## Building ##
 
 Building is done in a set of shell scripts. The scripts are to some extent order-dependent, and this is catered for here by a Makefile.


### PR DESCRIPTION
Loads of places reference this repository for how to get Ada GCC, but few mention that there are ready-built packages already available. IMHO the binaries should be part of the Releases, but that's another issue entirely :) Since the working binaries are what most people are after, I thought it would make sense to note this fact in the README. Alternatively, it could be in the Wiki - as I found no references there either.